### PR TITLE
Add Support for showing user's color on leaderboard

### DIFF
--- a/Leaderboard/OfflineLeaderboardTab.cs
+++ b/Leaderboard/OfflineLeaderboardTab.cs
@@ -4,11 +4,11 @@ using System.Threading;
 using TNRD.Zeepkist.GTR.Ghosting.Playback;
 using TNRD.Zeepkist.GTR.Messaging;
 using UnityEngine.Events;
-using Color = UnityEngine.Color;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
 using ZeepSDK.Leaderboard.Pages;
 using ZeepSDK.Level;
+using ZeepSDK.Utilities;
 
 namespace TNRD.Zeepkist.GTR.Leaderboard;
 
@@ -127,11 +127,13 @@ public class OfflineLeaderboardTab : BaseSingleplayerLeaderboardTab<LeaderboardR
         gui.favoriteButton.gameObject.SetActive(true);
         gui.isFavorite = _offlineGhostsService.ContainsAdditionalGhost(item.SteamId);
         gui.RedrawFavoriteImage();
-        gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
         if (PlayerManager.Instance.steamAchiever && PlayerManager.Instance.steamAchiever.GetPlayerSteamID().ToString() == item.SteamId)
-            gui.player_name.color = PlayerManager.Instance.GetChatColor();
+        {
+            string playerColor = UnityEngine.ColorUtility.ToHtmlStringRGB(PlayerManager.Instance.GetChatColor());
+            gui.player_name.text = $"<color=#{playerColor}><link=\"{item.SteamId}\">{item.SteamName}</link></color>";
+        }
         else
-            gui.player_name.color = Color.white;
+            gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
         gui.time.text = item.Time.GetFormattedTime();
 
         int placementPoints = Math.Max(0, Count - index);

--- a/Leaderboard/OfflineLeaderboardTab.cs
+++ b/Leaderboard/OfflineLeaderboardTab.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using TNRD.Zeepkist.GTR.Ghosting.Playback;
 using TNRD.Zeepkist.GTR.Messaging;
 using UnityEngine.Events;
+using Color = UnityEngine.Color;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
 using ZeepSDK.Leaderboard.Pages;
@@ -127,6 +128,10 @@ public class OfflineLeaderboardTab : BaseSingleplayerLeaderboardTab<LeaderboardR
         gui.isFavorite = _offlineGhostsService.ContainsAdditionalGhost(item.SteamId);
         gui.RedrawFavoriteImage();
         gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
+        if (PlayerManager.Instance.steamAchiever && PlayerManager.Instance.steamAchiever.GetPlayerSteamID().ToString() == item.SteamId)
+            gui.player_name.color = PlayerManager.Instance.GetChatColor();
+        else
+            gui.player_name.color = Color.white;
         gui.time.text = item.Time.GetFormattedTime();
 
         int placementPoints = Math.Max(0, Count - index);

--- a/Leaderboard/OnlineLeaderboardTab.cs
+++ b/Leaderboard/OnlineLeaderboardTab.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Threading;
 using TNRD.Zeepkist.GTR.Messaging;
+using ZeepkistClient;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
 using ZeepSDK.Level;
+using Color = UnityEngine.Color;
 
 namespace TNRD.Zeepkist.GTR.Leaderboard;
 
@@ -75,11 +77,20 @@ public class OnlineLeaderboardTab : BaseMultiplayerLeaderboardTab<LeaderboardRec
 
     protected override void OnDrawItem(GUI_OnlineLeaderboardPosition gui, LeaderboardRecord item, int index)
     {
+        ZeepkistNetwork.TryGetPlayer( Convert.ToUInt64(item.SteamId), out gui.thePlayer);
+        
         gui.position.gameObject.SetActive(true);
         gui.position.text = (index + 1).ToString();
         gui.position.color = PlayerManager.Instance.GetColorFromPosition(index + 1);
         gui.favoriteButton.gameObject.SetActive(false);
         gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
+        if (ZeepkistNetwork.LocalPlayer.SteamID.ToString() == item.SteamId)
+            gui.player_name.color = ZeepkistNetwork.LocalPlayer.chatColor;
+        else if (gui.thePlayer != null && gui.thePlayer.SteamID.ToString() == item.SteamId)
+            gui.player_name.color = gui.thePlayer.chatColor;
+        else
+            gui.player_name.color = Color.white;
+        
         gui.time.text = item.Time.GetFormattedTime();
 
         int placementPoints = Math.Max(0, Count - index);

--- a/Leaderboard/OnlineLeaderboardTab.cs
+++ b/Leaderboard/OnlineLeaderboardTab.cs
@@ -6,7 +6,7 @@ using ZeepkistClient;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
 using ZeepSDK.Level;
-using Color = UnityEngine.Color;
+using ZeepSDK.Utilities;
 
 namespace TNRD.Zeepkist.GTR.Leaderboard;
 
@@ -83,13 +83,20 @@ public class OnlineLeaderboardTab : BaseMultiplayerLeaderboardTab<LeaderboardRec
         gui.position.text = (index + 1).ToString();
         gui.position.color = PlayerManager.Instance.GetColorFromPosition(index + 1);
         gui.favoriteButton.gameObject.SetActive(false);
-        gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
+        UnityEngine.ColorUtility.ToHtmlStringRGB(PlayerManager.Instance.GetChatColor());
+
         if (ZeepkistNetwork.LocalPlayer.SteamID.ToString() == item.SteamId)
-            gui.player_name.color = ZeepkistNetwork.LocalPlayer.chatColor;
+        {
+            string playerColor = UnityEngine.ColorUtility.ToHtmlStringRGB(ZeepkistNetwork.LocalPlayer.chatColor);
+            gui.player_name.text = $"<color=#{playerColor}><link=\"{item.SteamId}\">{item.SteamName}</link></color>";
+        }
         else if (gui.thePlayer != null && gui.thePlayer.SteamID.ToString() == item.SteamId)
-            gui.player_name.color = gui.thePlayer.chatColor;
+        {
+            string playerColor = UnityEngine.ColorUtility.ToHtmlStringRGB(gui.thePlayer.chatColor);
+            gui.player_name.text = $"<color=#{playerColor}><link=\"{item.SteamId}\">{item.SteamName}</link></color>";
+        }
         else
-            gui.player_name.color = Color.white;
+            gui.player_name.text = $"<link=\"{item.SteamId}\">{item.SteamName}</link>";
         
         gui.time.text = item.Time.GetFormattedTime();
 


### PR DESCRIPTION
Uses the color set in Setting > Online > Player Name to color their scores in the GTR leaderboard
When in an online lobby will also use the players in the lobby to color their names if they have a record.